### PR TITLE
fix(ralph): worktree recipe cd and pipefail exit in wave plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,12 +500,13 @@ ralph_worktree:  ## Create a git worktree for Ralph and cd into it (BRANCH=requi
 
 ralph_run_worktree:  ## Create worktree + run Ralph in it (BRANCH=required, MAX_ITERATIONS=N, MODEL=sonnet|opus|haiku, RALPH_TIMEOUT=seconds, TEAMS=true|false)
 	$(if $(BRANCH),,$(error BRANCH is required. Usage: make ralph_run_worktree BRANCH=ralph/sprint-name))
-	bash ralph/scripts/ralph-in-worktree.sh "$(BRANCH)"
+	bash ralph/scripts/ralph-in-worktree.sh "$(BRANCH)" && \
+	cd "../$$(basename $(BRANCH))" && \
 	$(if $(RALPH_TIMEOUT),timeout $(RALPH_TIMEOUT)) \
 		RALPH_MODEL=$(MODEL) MAX_ITERATIONS=$(MAX_ITERATIONS) \
 		RALPH_TEAMS=$(TEAMS) \
 		$(if $(filter true,$(TEAMS)),CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1) \
-		bash -c 'cd "../$$(basename $(BRANCH))" && bash ralph/scripts/ralph.sh' \
+		bash ralph/scripts/ralph.sh \
 		|| { EXIT_CODE=$$?; [ $$EXIT_CODE -eq 124 ] && echo "Ralph worktree timed out after $(RALPH_TIMEOUT)s"; exit $$EXIT_CODE; }
 
 ralph_stop:  ## Stop all running Ralph loops (keeps state and data)

--- a/ralph/scripts/ralph.sh
+++ b/ralph/scripts/ralph.sh
@@ -272,14 +272,14 @@ print_dependency_tree() {
 
     log_info "$header"
     echo "$tree_output" | while IFS= read -r line; do
-        [ -n "$line" ] && log_info "$line"
+        [ -n "$line" ] && log_info "$line" || true
     done
 
     if [ -n "$blocking_output" ]; then
         log_info ""
         log_info "  Blocking relationships:"
         echo "$blocking_output" | while IFS= read -r line; do
-            [ -n "$line" ] && log_info "$line"
+            [ -n "$line" ] && log_info "$line" || true
         done
     fi
 


### PR DESCRIPTION
## Summary

- **Worktree recipe fix**: Chain worktree creation, `cd`, and Ralph execution in a single shell line so failure at any step stops the recipe
- **Pipefail fix**: `[ -n "$line" ] && log_info "$line"` returns exit code 1 on empty trailing lines in wave plan output, killing the script under `set -euo pipefail`. Added `|| true` to both `echo | while read` loops in `print_dependency_tree`
- **New recipe**: `ralph_run_worktree` creates worktree + runs Ralph (split from `ralph_worktree` which now only creates the worktree)

## Test plan

- [x] `make ralph_run_worktree BRANCH=ralph/sprint9-correctness-security TEAMS=true MODEL=opus` passes wave plan and enters iteration 1
- [x] `make ralph_worktree BRANCH=...` creates worktree and prints cd path

🤖 Generated with Claude <noreply@anthropic.com>