### PR TITLE
chore: add compound-learning rule and sync cc-meta skills

### DIFF
--- a/.claude/rules/compound-learning.md
+++ b/.claude/rules/compound-learning.md
@@ -1,0 +1,21 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
+4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication

--- a/.claude/skills/compacting-context/SKILL.md
+++ b/.claude/skills/compacting-context/SKILL.md
@@ -16,7 +16,7 @@ Distills verbose outputs into structured summaries following ACE-FCA principles.
 
 ## When to Use
 
-Per `.claude/rules/context-management.md`:
+Per `references/context-management.md`:
 - After verbose tool output (logs, JSON, search results)
 - After completing a phase or milestone
 

--- a/.claude/skills/compacting-context/references/context-management.md
+++ b/.claude/skills/compacting-context/references/context-management.md
@@ -1,0 +1,59 @@
+# Context Management (ACE-FCA)
+
+Principles for optimal context window utilization.
+
+## Context Quality Equation
+
+Quality output = Correct context + Complete context + Minimal noise
+
+## Degradation Hierarchy (worst to best)
+
+1. **Incorrect information** - worst, causes cascading errors (garbage in, garbage out)
+2. **Missing information** - leads to assumptions (agent guesses, sometimes wrong)
+3. **Excessive noise** - dilutes signal, wastes capacity (truth buried but still there)
+
+Better to have less correct info than more info with errors.
+
+## Utilization Target
+
+Keep context at **40-60%** capacity. Leave room for:
+
+- Model reasoning
+- Output generation
+- Error recovery
+
+## Context Pollution Sources (What)
+
+These mess up context - compact/summarize immediately:
+
+- File searches (glob/grep results)
+- Code flow traces
+- Edit applications
+- Test/build logs
+- Large JSON blobs from tools
+
+## Workflow Phases
+
+Research → Planning → Implementation. Compact after each phase transition.
+
+## Compaction Triggers (When)
+
+Use `compacting-context` skill when:
+
+- Verbose tool output (logs, JSON, search results)
+- After completing a phase or milestone
+- Before starting new complex task
+
+## Subagent Usage
+
+Use `researching-codebase` skill to:
+
+- Isolate discovery artifacts from main context
+- Return structured findings only
+- Prevent search noise pollution
+
+## Output Guidelines
+
+- Prefer structured summaries over raw dumps
+- Extract only relevant portions from large files
+- Use targeted searches, not broad sweeps

--- a/.claude/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/.claude/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: synthesizing-cc-bigpicture
+description: Synthesizes a living big-picture meta-plan from Claude Code sessions, plans, tasks, and team communications. Use when orienting across projects, assessing reasoning modes, or creating a plan-to-plan overview.
+compatibility: Designed for Claude Code
+metadata:
+  allowed-tools: Read, Grep, Glob
+  argument-hint: [project-name] [time-range] [output-path]
+  context: fork
+---
+
+# Big-Picture Synthesis
+
+**Target**: $ARGUMENTS
+
+Synthesizes a **plan to plan** — an overarching view across all Claude Code
+artifacts. Not a search tool. A reasoning tool that connects sessions, plans,
+tasks, and memories into a coherent narrative of what you're working on, why,
+and where you're headed.
+
+## Arguments
+
+| Position | Name | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| 1 | `project-name` | no | all projects | Filter to a single project. Matched against decoded project paths (substring, case-insensitive). E.g. `Agents-eval`, `polyforge`. |
+| 2 | `time-range` | no | all time | Limit to recent activity. E.g. `7d`, `30d`, `this-week`. |
+| 3 | `output-path` | no | auto (see below) | Where to write the output file. |
+
+**Default output path:**
+- When `project-name` is `all` or omitted: `~/.claude/bigpicture.md` (global)
+- When `project-name` is set: `<decoded-project-path>/docs/bigpicture.md` (project-local).
+  The project path is decoded from `~/.claude/projects/<encoded-path>/` (e.g.
+  `-workspaces-Agents-eval` → `/workspaces/Agents-eval/docs/bigpicture.md`).
+- When `output-path` is explicitly provided: uses that path regardless of filter.
+
+**Examples:**
+
+```
+/synthesizing-cc-bigpicture                          # All projects → ~/.claude/bigpicture.md
+/synthesizing-cc-bigpicture Agents-eval              # Single project → /workspaces/Agents-eval/docs/bigpicture.md
+/synthesizing-cc-bigpicture Agents-eval 7d           # Single project, last 7 days → project docs/
+/synthesizing-cc-bigpicture all 30d ./bigpicture.md  # All projects, 30 days, custom output path
+```
+
+**Project matching**: The `project-name` is matched against the decoded
+`~/.claude/projects/<encoded-path>/` directories. The encoding replaces `/`
+with `-` (e.g. `-workspaces-Agents-eval` → `/workspaces/Agents-eval`). A
+substring match on any path segment is sufficient. Use `all` to explicitly
+select all projects.
+
+## Three Reasoning Axes
+
+Track these per work stream to surface where you are and what shift is needed:
+
+### Diverge / Converge
+
+- **Diverge**: Expanding — brainstorming, exploring options, opening questions
+- **Converge**: Narrowing — selecting approaches, committing, closing questions
+- **Signals**: Open questions in plans = diverging. Task completion clustering = converging. Multiple branches = diverging. Merge activity = converging.
+- **Alert**: Diverging for N sessions without convergence → decision debt
+
+### Inductive / Deductive
+
+- **Inductive** (bottom-up reasoning): Observations → patterns → principles
+- **Deductive** (top-down reasoning): Principles → predictions → implementations
+- **Signals**: `## Learnings` in session-memory, AGENT_LEARNINGS = inductive. PRD/plan goals driving task creation = deductive.
+- **Alert**: Implementing without learning (assumptions) or learning without formalizing into plans (knowledge not actionized)
+
+### Top-down / Bottom-up
+
+- **Top-down**: Strategy → decomposition → tasks (PRD → architecture → implementation)
+- **Bottom-up**: Details → integration → strategy (bugs reveal gaps, tests surface flaws)
+- **Signals**: PRD→task flow = top-down. Blockers→plan revisions, AGENT_REQUESTS = bottom-up.
+- **Alert**: All top-down (no implementation feedback) or all bottom-up (reactive without direction)
+
+## When to Use
+
+- Starting a work session — orient across projects
+- Planning what to work on next — strategic prioritization
+- Sprint/week boundary — maintain the meta-plan
+- Feeling stuck — surface current reasoning mode and whether a shift is needed
+- Onboarding someone to your work streams
+
+## Do Not Use
+
+- For searching a specific past conversation (use `/resume` or `/history`)
+- For per-session context (session-memory does this automatically)
+- For modifying or deleting session history
+- For real-time usage monitoring (use `/insights`)
+
+## CC Data Sources
+
+```
+~/.claude/
+├── history.jsonl                              # Global prompt log (display, timestamp, project, sessionId)
+├── stats-cache.json                           # Daily aggregates (messageCount, sessionCount, toolCallCount)
+├── projects/<encoded-path>/
+│   ├── memory/MEMORY.md                       # Per-project persistent knowledge
+│   ├── <session-uuid>.jsonl                   # Full transcripts (metadata-scan only, never bulk-read)
+│   └── <session-uuid>/
+│       ├── subagents/agent-<id>.jsonl         # Subagent transcripts
+│       └── tool-results/toolu_<id>.txt        # Large tool result storage
+├── plans/*.md                                 # Plan mode files (whimsical auto-names)
+├── tasks/<session-or-team-name>/
+│   ├── .lock, .highwatermark                  # State files
+│   └── <N>.json                               # Tasks (id, subject, description, status, activeForm, owner, blocks, blockedBy)
+└── teams/<team-name>/
+    ├── config.json                            # Team config (name, description, members with model/prompt/role)
+    └── inboxes/<member-name>.json             # Agent-to-agent messages (from, text, summary, timestamp)
+```
+
+See `references/cc-entry-types.md` for JSONL entry type reference.
+
+## Workflow
+
+1. **Parse arguments** — Extract `project-name`, `time-range`, and `output-path`
+   from `$ARGUMENTS` per the Arguments table above. Apply defaults for omitted params.
+   **Resolve output path**: If `output-path` is not explicitly provided, apply the
+   default: when `project-name` is set (not `all`), decode the matched project path
+   from `~/.claude/projects/<encoded-path>/` and write to `<decoded-path>/docs/bigpicture.md`.
+   When `project-name` is `all` or omitted, write to `~/.claude/bigpicture.md`.
+
+2. **Check existing** — Read output path. If bigpicture.md exists, load it for
+   incremental update (preserve structure, update content).
+
+3. **Discover projects** — Glob `~/.claude/projects/*/memory/MEMORY.md` and
+   `~/.claude/projects/*/*.jsonl`. Decode project names from path encoding
+   (`-` → `/`). If `project-name` is set and not `all`, filter to directories
+   whose decoded path contains the value (case-insensitive substring match).
+
+4. **Collect signals** (sequential, metadata-first — no subagents):
+   a. **Activity**: Read `~/.claude/stats-cache.json` — daily message/session/tool-call counts for trajectory
+   b. **Sessions**: Read `~/.claude/history.jsonl` — extract unique sessionIds per project, timestamps, prompt topics.
+      **When `project-name` is set**: filter history entries to those whose `project` field
+      contains the project name (case-insensitive). Collect the matching `sessionId` values
+      into a **session allowlist** for use in steps 4e and 4h.
+   c. **Projects**: Glob `~/.claude/projects/*/memory/MEMORY.md` — persistent knowledge per project
+      (already filtered by step 3)
+   d. **Plans**: Glob + Read `~/.claude/plans/*.md` — goals, open questions, decisions, scope.
+      **When `project-name` is set**: only include plans that mention the project name
+      in their content (case-insensitive grep). Exclude plans that don't reference the
+      filtered project. This is a content-based filter since plan files have no project
+      metadata in their filenames.
+   e. **Tasks**: Glob + Read `~/.claude/tasks/*/*.json` — skip `.lock`/`.highwatermark`,
+      parse dependency graph + status.
+      **When `project-name` is set**: correlate task directory names against the session
+      allowlist from step 4b. Task dirs named as session UUIDs match if the UUID is in the
+      allowlist. Task dirs named as team names match via step 4f. Exclude unmatched dirs.
+   f. **Teams**: Glob + Read `~/.claude/teams/*/config.json` — team structure, member roles, models.
+      **When `project-name` is set**: only include teams whose `config.json` description or
+      member prompts reference the project name (case-insensitive grep). Collect matching
+      team names for use in step 4e task dir correlation.
+   g. **Team comms**: Glob + Read `~/.claude/teams/*/inboxes/*.json` — agent findings,
+      cross-agent synthesis. Only read inboxes for teams that passed the filter in step 4f.
+   h. **Session metadata**: For recent sessions, read first+last 5 lines of `.jsonl` files
+      to extract timestamps, branches, user prompts (never bulk-read full transcripts).
+      **When `project-name` is set**: only read `.jsonl` files whose session UUID is in
+      the session allowlist from step 4b.
+   i. **Project docs**: For each project in `projects/`, decode the project path
+      and scan for `docs/roadmap.md`, `CHANGELOG.md`, `AGENT_REQUESTS.md`.
+      Extract: sprint status table, `[Unreleased]` changes, backlog items, open requests.
+      (Already filtered by step 3.)
+
+   **Critical**: Never read full session `.jsonl` transcripts in bulk. Use
+   `history.jsonl` for session discovery and first+last lines for metadata only.
+
+   **Critical**: When `project-name` is set, ALL sections of the output must respect the
+   filter. Do not include plans, tasks, teams, blockers, or mode transitions from other
+   projects. The only exception is "Cross-Project Connections" which may reference other
+   projects but only as they relate *to* the filtered project (outbound connections).
+
+5. **Classify reasoning modes** per work stream:
+   - Count open questions vs. closed decisions in plans → diverge/converge
+   - Count learning entries vs. plan-driven tasks → inductive/deductive
+   - Trace flow: PRD→tasks (top-down) vs. blockers→revisions (bottom-up)
+   - Flag mismatches per axis (see alerts above)
+
+6. **Synthesize connections**:
+   - Group sessions by project, then by time clusters (work streams)
+   - Link plans → sessions (timestamp + project correlation)
+   - Link tasks → plans (session-id in task path)
+   - Identify recurring themes across project memories
+   - Surface blockers: tasks with unresolved `blockedBy`
+   - Detect trajectory: momentum (recent activity) vs. stale (no sessions in N days)
+   - **When `project-name` is set**: Only synthesize filtered data. The "Cross-Project
+     Connections" section shows only outbound connections *from* the filtered project.
+     All other sections (Active Plans, Blockers, Mode Transitions, TODOs & DONEs) must
+     contain ONLY items from the filtered project. If a plan/task/team didn't pass the
+     filter in step 4, it must not appear anywhere in the output.
+
+7. **Output** using format below. Write to output path.
+
+## Output Format
+
+```markdown
+# Big Picture — <date>
+
+## Reasoning Mode Summary
+
+| Project | Phase | D/C | I/D | T/B | Alert |
+|---------|-------|-----|-----|-----|-------|
+| <name>  | <phase> | Diverging | Inductive | Bottom-up | <alert or —> |
+
+Legend: D/C = Diverge/Converge, I/D = Inductive/Deductive, T/B = Top-down/Bottom-up
+
+## Active Work Streams
+
+### <Project Name>
+- **Status:** <active/stalled/completed> — <N sessions in last 7d>
+- **Current focus:** <from latest summaries + memory>
+- **Reasoning mode:** <diverging+inductive = exploring> | <converging+deductive = building>
+- **Key decisions:** <from plans + session memory>
+- **Open questions:** <unresolved — divergence points>
+- **Open tasks:** <N open> / <N total> — blockers: <list>
+- **Trajectory:** <accelerating/steady/stalled>
+
+## Cross-Project Connections
+<!-- When project-name is set: only show outbound connections FROM the filtered project.
+     When no filter: show all cross-project links. Omit section entirely if no connections. -->
+- <Filtered Project> depends on / informs <Other Project>: <specific connection>
+- Shared pattern: "<theme across memories>"
+
+## Active Plans
+| Plan | Project | Mode | Status | Key Goals |
+|------|---------|------|--------|-----------|
+
+## Project-Arching TODOs & DONEs
+
+### <Project Name>
+
+**Shipped (DONEs):**
+- <Sprint/version>: <summary> — from roadmap.md / CHANGELOG.md
+
+**In Progress:**
+- [Unreleased]: <summary> — from CHANGELOG.md
+- <N> tasks across <M> team dirs (<team names>)
+
+**Pending (TODOs):**
+- Backlog: <items> — from roadmap.md
+- <N> pending CC tasks across <M> task dirs
+- <N> open agent requests — from AGENT_REQUESTS.md
+
+**Stale:**
+- Tasks pending >7 days with no activity
+
+## Blockers & Stale Items
+- Task "<subject>" blocked since <date>
+- Project "<name>" — no sessions in <N> days
+
+## Mode Transitions Needed
+- <Project>: Shift diverging → converging (enough options explored)
+- <Project>: Shift top-down → bottom-up (implementation feedback needed)
+- <Project>: Formalize learnings (inductive) into plan updates (deductive)
+```
+
+## Common Pitfalls
+
+- **Data dump instead of synthesis**: If output exceeds ~200 lines, raise abstraction level. The skill interprets, not lists.
+- **Stale big picture**: Only as fresh as last invocation. Not auto-updating.
+- **Reading full transcripts**: Use `history.jsonl` for session discovery and first+last lines for metadata. Never bulk-read `.jsonl` files.
+- **False mode classification**: Reasoning modes are heuristic signals, not definitive judgments. Present as evidence-based assessment.
+- **Spawning subagents**: Do not use Agent tool. Sequential processing within the fork context is sufficient. Only justified at extreme scale (50+ projects) with explicit user request.
+
+## Quality Check
+
+- Correct > Complete > Minimal (ACE-FCA)
+- ~100-200 lines output (concise, not exhaustive)
+- Every claim traces to a specific CC artifact (file path, session summary, plan name)
+- Incremental update preserves structure, refreshes content
+- No subagents spawned during normal operation
+
+## References
+
+See `references/cc-entry-types.md` for JSONL session entry type taxonomy.

--- a/.claude/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
+++ b/.claude/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
@@ -1,0 +1,130 @@
+# Claude Code JSONL Entry Types
+
+Reference for parsing `~/.claude/projects/<path>/<session-uuid>.jsonl` files.
+
+Source: `randlee/claude-history` entry type taxonomy + CC filesystem documentation.
+
+## Session Transcript Entries
+
+Each line in a session `.jsonl` file is a JSON object with a `type` field:
+
+| Type | Description | Key Fields |
+|------|-------------|------------|
+| `user` | User messages (prompts or tool results) | `uuid`, `parentUuid`, `timestamp`, `message` |
+| `assistant` | Claude responses with text and tool_use | `uuid`, `parentUuid`, `timestamp`, `message` |
+| `system` | System events and hook summaries | `timestamp`, `event` |
+| `queue-operation` | Subagent spawn triggers | `agentId`, `sessionId` |
+| `progress` | Status updates during processing | `timestamp`, `status` |
+| `file-history-snapshot` | Git state captured at session start | `staged`, `unstaged`, `untracked` |
+| `summary` | Conversation summaries (from auto-compaction) | `timestamp`, `content` |
+| `result` | Session completion markers | `timestamp`, `status` |
+
+## Global History
+
+`~/.claude/history.jsonl` — global prompt log, one entry per user message:
+
+```json
+{
+  "display": "the user prompt text",
+  "timestamp": "2026-03-20T14:30:00Z",
+  "project": "/workspaces/my-project",
+  "sessionId": "uuid"
+}
+```
+
+Use for session discovery (unique `sessionId` values), timeline reconstruction,
+and prompt topic analysis. Preferred over globbing `.jsonl` files when
+`sessions-index.json` is unavailable.
+
+## Stats Cache
+
+`~/.claude/stats-cache.json` — daily activity aggregates:
+
+```json
+{
+  "2026-03-20": {
+    "messageCount": 42,
+    "sessionCount": 5,
+    "toolCallCount": 128
+  }
+}
+```
+
+Use for trajectory signal (active vs. stale days, trend detection).
+
+## Plans
+
+`~/.claude/plans/*.md` — plain markdown files with plan names as filenames
+(often auto-generated whimsical names like `tingly-weaving-kite.md`).
+
+## Tasks
+
+`~/.claude/tasks/<session-or-team-name>/<N>.json` — structured objects:
+
+```json
+{
+  "id": "3",
+  "subject": "Task title",
+  "description": "Task details",
+  "status": "in_progress",
+  "activeForm": "agent-form",
+  "owner": "member-name",
+  "blocks": ["4", "5"],
+  "blockedBy": ["1"]
+}
+```
+
+The `blocks`/`blockedBy` arrays create a dependency graph within a task list.
+Task directories also contain `.lock` and `.highwatermark` state files (skip these).
+
+## Teams
+
+`~/.claude/teams/<team-name>/` — directory per team:
+
+- `config.json` — team configuration:
+
+  ```json
+  {
+    "name": "team-name",
+    "description": "Team purpose",
+    "members": [
+      {
+        "name": "member-name",
+        "model": "claude-sonnet-4-6",
+        "prompt": "system prompt",
+        "role": "developer"
+      }
+    ]
+  }
+  ```
+
+- `inboxes/<member-name>.json` — agent-to-agent messages:
+
+  ```json
+  [
+    {
+      "from": "other-member",
+      "text": "Full message content",
+      "summary": "Brief summary",
+      "timestamp": "2026-03-20T14:30:00Z"
+    }
+  ]
+  ```
+
+## Subagent Transcripts
+
+`~/.claude/projects/<path>/<session-uuid>/subagents/agent-<id>.jsonl` — full
+transcripts of subagent sessions spawned within a parent session. Same entry
+format as session `.jsonl` files.
+
+## Project Memory
+
+`~/.claude/projects/<path>/memory/MEMORY.md` — persistent per-project knowledge
+loaded at conversation start.
+
+## Path Encoding
+
+Project paths are URL-encoded with dashes:
+- `/home/user/myapp` → `-home-user-myapp`
+- `/workspaces/Agents-eval` → `-workspaces-Agents-eval`
+- `C:\Users\name\project` → `C--Users-name-project`


### PR DESCRIPTION
## Summary

- Add compound-learning rule (rule-of-three promotion path for preventing repeated mistakes)
- Sync cc-meta skills locally: compacting-context references, synthesizing-cc-bigpicture
- Fix compacting-context SKILL.md reference path

## Files

- `.claude/rules/compound-learning.md` (new)
- `.claude/skills/compacting-context/SKILL.md` (fix reference path)
- `.claude/skills/compacting-context/references/context-management.md` (new)
- `.claude/skills/synthesizing-cc-bigpicture/SKILL.md` (new)
- `.claude/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md` (new)

Generated with Claude <noreply@anthropic.com>