### PR TITLE
fix(plugins): correct marketplace name to qte77-claude-code-utils

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,15 +71,15 @@
     "command": "bash .claude/scripts/statusline.sh"
   },
   "enabledPlugins": {
-    "docs-generator@qte77-claude-code-plugins": true,
+    "docs-generator@qte77-claude-code-utils": true,
     "context7@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "cc-meta@qte77-claude-code-plugins": true
+    "cc-meta@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-plugins": {
+    "qte77-claude-code-utils": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-plugins"


### PR DESCRIPTION
## Summary
- Rename marketplace key `qte77-claude-code-plugins` → `qte77-claude-code-utils` in `.claude/settings.json`
- Aligns with marketplace self-identifier at `qte77/claude-code-plugins`; `source.repo` unchanged

## Why
The marketplace at `qte77/claude-code-plugins` self-identifies as `qte77-claude-code-utils`. The mismatched key caused `/reload-plugins` to fail with `Plugin not found in marketplace` for every entry.

## Test plan
- [ ] `/reload-plugins` reports 0 errors
- [ ] `/doctor` shows no marketplace mismatches

Mirrors qte77/polyforge-orchestrator#60.

Generated with Claude <noreply@anthropic.com>