### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.claude/skills/compacting-context/SKILL.md
+++ b/.claude/skills/compacting-context/SKILL.md
@@ -45,7 +45,7 @@ Per `references/context-management.md`:
 
 ## Findings
 <!-- key discoveries, distilled outputs from logs/JSON/tests -->
-```
+```text
 
 ## Quality Check
 

--- a/.claude/skills/creating-pr-from-branch/SKILL.md
+++ b/.claude/skills/creating-pr-from-branch/SKILL.md
@@ -42,9 +42,9 @@ its sections. If not, use this minimal format:
 ## Commits
 
 <list commits from git log>
-```
+```bash
 
-**Body guidelines:**
+### Body guidelines:
 - Fill template checkboxes where applicable (check items that are done)
 - Include `Closes #N` if the branch name contains an issue number
 - Keep it concise — the diff speaks for itself

--- a/.claude/skills/designing-backend/SKILL.md
+++ b/.claude/skills/designing-backend/SKILL.md
@@ -9,12 +9,14 @@ metadata:
   allowed-tools: Read, Grep, Glob, WebSearch, WebFetch
 ---
 
+# Skill
+
 ## Git Context
 
 - Recent changes: !`git log --oneline -3`
 - Current branch: !`git branch --show-current`
 
-# Backend Architecture
+## Backend Architecture
 
 **Target**: $ARGUMENTS
 

--- a/.claude/skills/enforcing-doc-hierarchy/SKILL.md
+++ b/.claude/skills/enforcing-doc-hierarchy/SKILL.md
@@ -21,7 +21,7 @@ approval.
 Discover from the project's `CONTRIBUTING.md` "Documentation Hierarchy" section
 (or equivalent). Typical chain:
 
-```
+```text
 UserStory / PRD (requirements, scope — PRIMARY AUTHORITY)
   → architecture.md (technical design)
     → Sprint / implementation docs (current state)
@@ -31,7 +31,7 @@ UserStory / PRD (requirements, scope — PRIMARY AUTHORITY)
 
 ### 2. Claude Code Infrastructure
 
-```
+```text
 CLAUDE.md (entry point)
   → AGENTS.md (behavioral rules, compliance, decision framework)
     → CONTRIBUTING.md (technical workflows, commands, coding standards)

--- a/.claude/skills/generating-interactive-userstory-md/SKILL.md
+++ b/.claude/skills/generating-interactive-userstory-md/SKILL.md
@@ -45,4 +45,4 @@ See `ralph/docs/templates/userstory.md.template` for structure and placeholders.
 
 ```bash
 make ralph_userstory
-```
+```text

--- a/.claude/skills/generating-prd-json-from-prd-md/SKILL.md
+++ b/.claude/skills/generating-prd-json-from-prd-md/SKILL.md
@@ -17,7 +17,7 @@ Hybrid approach: Python script parses, AI validates and corrects.
 
 ```bash
 python ralph/scripts/generate_prd_json.py --dry-run
-```
+```bash
 
 Check output for: declared vs parsed story count mismatch, missing stories, empty acceptance/files. If issues found, fix PRD markdown or note for manual correction in step 3.
 
@@ -80,7 +80,7 @@ See `ralph/docs/templates/prd.json.template` for structure and fields.
 
 ```bash
 make ralph_prd_json
-```
+```bash
 
 ## Next Steps
 

--- a/.claude/skills/generating-writeup/SKILL.md
+++ b/.claude/skills/generating-writeup/SKILL.md
@@ -51,7 +51,7 @@ make pandoc_run \
   INPUT_FILES="$$(printf '%s\036' $$dir/*.md)" \
   OUTPUT_FILE="$$dir/output.pdf" \
   BIBLIOGRAPHY="$$dir/references.bib"
-```
+```bash
 
 With custom citation style:
 

--- a/.claude/skills/generating-writeup/research-paper-plan.md
+++ b/.claude/skills/generating-writeup/research-paper-plan.md
@@ -33,7 +33,7 @@ Fill in `{{PLACEHOLDERS}}` with project-specific content before execution.
 
 ## File Structure
 
-```
+```text
 docs/write-up/{{TOPIC}}/
 ├── 00_frontmatter.md           # YAML frontmatter (title, bibliography, CSL)
 ├── 01_introduction.md          # Problem, motivation, scope, timeline, usage

--- a/.claude/skills/maintaining-agents-md/SKILL.md
+++ b/.claude/skills/maintaining-agents-md/SKILL.md
@@ -37,7 +37,7 @@ references, missing updates, and promotion candidates.
 
 Scan governance files for staleness and inconsistencies.
 
-**Checks:**
+### Checks:
 
 1. **Stale paths**: Grep governance files for `src/`, `docs/`, `tests/` paths.
    Verify each path still exists.
@@ -65,7 +65,7 @@ Fix staleness found by audit. For each finding:
 Evaluate `AGENT_LEARNINGS.md` entries for promotion per the criteria in
 `.claude/rules/compound-learning.md` (3rd occurrence → rule, recurring → skill).
 
-**Procedure:**
+### Procedure:
 
 1. Read `AGENT_LEARNINGS.md` entries
 2. Grep codebase for each pattern's problem statement

--- a/.claude/skills/researching-codebase/SKILL.md
+++ b/.claude/skills/researching-codebase/SKILL.md
@@ -62,7 +62,7 @@ files_examined: <count>
 
 - Constraint with evidence (`path:line`)
 
-```
+```text
 
 ## Evidence Requirements
 

--- a/.claude/skills/researching-website-design/SKILL.md
+++ b/.claude/skills/researching-website-design/SKILL.md
@@ -37,7 +37,7 @@ never seen a website?"
 1. [Company] - [URL] - Authority: [H/M/L]
    Cites: [Studies/sources referenced]
    Cross-refs: [Shared sources with other sites]
-```
+```yaml
 
 ### Design Breakthroughs (Max 3)
 
@@ -56,7 +56,7 @@ COLORS: Primary #HEX [effect], Accent #HEX [effect]
 TYPOGRAPHY: Headers [font/weight], Body [font/size]
 HEADLINES: "[Pattern]" - [User psychology]
 CTAS: "[Button text]" - [Action driver]
-```
+```yaml
 
 ### Contrarian Insights
 
@@ -72,7 +72,7 @@ Evidence: [Sources]
 ELIMINATE: [Element hurting UX]
 SIMPLIFY: [Over-complex pattern]
 ADOPT: [Underused effective pattern]
-```
+```text
 
 ## Rules
 

--- a/.claude/skills/synthesizing-cc-bigpicture/SKILL.md
+++ b/.claude/skills/synthesizing-cc-bigpicture/SKILL.md
@@ -24,7 +24,7 @@ into a coherent narrative of what you're working on, why, and where you're heade
 | 2 | `time-range` | no | all time | E.g. `7d`, `30d`, `this-week`. |
 | 3 | `output-path` | no | auto | Where to write output. |
 
-**Default output path:**
+### Default output path:
 - `project-name` set: `<decoded-project-path>/docs/bigpicture.md`
 - `all` or omitted: `~/.claude/bigpicture.md`
 - Explicit `output-path`: overrides both.
@@ -32,9 +32,9 @@ into a coherent narrative of what you're working on, why, and where you're heade
 **Project matching**: Matched against decoded `~/.claude/projects/<encoded-path>/`
 directories (`-` → `/` in encoding). Substring match on any path segment.
 
-**Examples:**
+### Examples:
 
-```
+```text
 /synthesizing-cc-bigpicture                          # All → ~/.claude/bigpicture.md
 /synthesizing-cc-bigpicture Agents-eval              # Single → project docs/
 /synthesizing-cc-bigpicture Agents-eval 7d           # Single, last 7 days
@@ -74,7 +74,7 @@ Track per work stream to surface where you are and what shift is needed.
 
 ## CC Data Sources
 
-```
+```text
 ~/.claude/
 ├── history.jsonl                    # Global prompt log (display, timestamp, project, sessionId)
 ├── stats-cache.json                 # Daily aggregates (messageCount, sessionCount, toolCallCount)
@@ -161,7 +161,7 @@ respect the filter. Apply these rules once, consistently:
 ## TODOs & DONEs
 ## Blockers & Stale Items
 ## Mode Transitions Needed
-```
+```text
 
 ## Common Pitfalls
 

--- a/.claude/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
+++ b/.claude/skills/synthesizing-cc-bigpicture/references/cc-entry-types.md
@@ -30,7 +30,7 @@ Each line in a session `.jsonl` file is a JSON object with a `type` field:
   "project": "/workspaces/my-project",
   "sessionId": "uuid"
 }
-```
+```text
 
 Use for session discovery (unique `sessionId` values), timeline reconstruction,
 and prompt topic analysis. Preferred over globbing `.jsonl` files when
@@ -72,7 +72,7 @@ Use for trajectory signal (active vs. stale days, trend detection).
   "blocks": ["4", "5"],
   "blockedBy": ["1"]
 }
-```
+```text
 
 The `blocks`/`blockedBy` arrays create a dependency graph within a task list.
 Task directories also contain `.lock` and `.highwatermark` state files (skip these).

--- a/.claude/skills/testing-python/SKILL.md
+++ b/.claude/skills/testing-python/SKILL.md
@@ -46,7 +46,7 @@ def test_order_processor_calculates_total():
 
     # ASSERT
     assert total == 25.00
-```
+```text
 
 ## Hypothesis Priorities (Edge Cases within TDD)
 
@@ -82,7 +82,7 @@ make test_rerun        # Rerun failed tests (fast iteration)
 make validate          # Full pre-commit validation
 pytest tests/ -v       # Verbose
 pytest -k test_user_   # Filter by name
-```
+```bash
 
 ## Quality Gates
 

--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ agents.** For technical workflows and coding standards, see
 [CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
 [README.md](README.md).
 
-**External References:**
+### External References:
 
 - @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
 - @AGENT_REQUESTS.md - Escalation and human collaboration
@@ -54,7 +54,7 @@ using Skills.
 **Priority Order:** User instructions → AGENTS.md compliance → Documentation
 hierarchy → Project patterns → General best practices
 
-**Information Source Rules:**
+### Information Source Rules:
 
 - **Requirements/scope:** PRD.md ONLY (PRIMARY AUTHORITY)
 - **User workflows:** UserStory.md ONLY (AUTHORITY)  
@@ -63,18 +63,18 @@ hierarchy → Project patterns → General best practices
 - **Operations:** Usage guides ONLY (AUTHORITY)
 - **Research:** Landscape documents (INFORMATIONAL ONLY)
 
-**Anti-Scope-Creep Rules:**
+### Anti-Scope-Creep Rules:
 
 - **NEVER implement landscape possibilities without PRD.md validation**
 - **Landscape documents are research input ONLY, not implementation requirements**
 - **Always validate implementation decisions against PRD.md scope boundaries**
 
-**Anti-Redundancy Rules:**
+### Anti-Redundancy Rules:
 
 - **NEVER duplicate information across documents** - reference authoritative sources
 - **Update authoritative document, then remove duplicates elsewhere**
 
-**When to Escalate to AGENT_REQUESTS.md:**
+### When to Escalate to AGENT_REQUESTS.md:
 
 - User instructions conflict with safety/security practices
 - AGENTS.md rules contradict each other
@@ -87,7 +87,7 @@ Multi-Agent System (MAS) evaluation framework using **PydanticAI** for agent
 orchestration. For detailed architecture, see
 [architecture.md](docs/architecture.md).
 
-**Code Organization Principles:**
+### Code Organization Principles:
 
 - Maintain modularity: Keep files focused and manageable
 - Follow established patterns: Use consistent structure and naming
@@ -98,7 +98,7 @@ orchestration. For detailed architecture, see
 
 ## Agent Neutrality Requirements
 
-**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+### ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:
 
 1. **Extract requirements from specified documents ONLY**
    - Read provided sprint documents, task descriptions, or reference materials
@@ -117,7 +117,7 @@ orchestration. For detailed architecture, see
    - Follow "minimal," "streamlined," or "focused" guidance literally
    - Do NOT over-engineer solutions beyond stated needs
 
-**Scope Validation Checkpoints (MANDATORY):**
+### Scope Validation Checkpoints (MANDATORY):
 
 - **Before design completion**: Validate design stays within specified task scope
 - **Before handoff**: Confirm complexity matches stated targets
@@ -130,7 +130,7 @@ orchestration. For detailed architecture, see
 
 ### MANDATORY Compliance Requirements for All Subagents
 
-**ALL SUBAGENTS MUST STRICTLY ADHERE TO THE FOLLOWING:**
+### ALL SUBAGENTS MUST STRICTLY ADHERE TO THE FOLLOWING:
 
 1. **Separation of Concerns (MANDATORY)**:
    - **Architects MUST NOT implement code** - only design, plan, and specify
@@ -173,25 +173,25 @@ orchestration. For detailed architecture, see
    - **MUST use absolute imports** not relative imports
    - **MUST add `# Reason:` comments** for complex logic only when necessary
 
-**FAILURE TO FOLLOW THESE REQUIREMENTS WILL RESULT IN TASK REJECTION**  
+### FAILURE TO FOLLOW THESE REQUIREMENTS WILL RESULT IN TASK REJECTION
 
 ### Role-Specific Agent Boundaries
 
-**ARCHITECTS (backend-architect, agent-systems-architect, evaluation-specialist):**
+### ARCHITECTS (backend-architect, agent-systems-architect, evaluation-specialist):
 
 - **SCOPE**: Design, plan, specify requirements, create architecture diagrams
 - **DELIVERABLES**: Technical specifications, architecture documents, requirement lists
 - **FORBIDDEN**: Writing implementation code, making code changes, running tests
 - **HANDOFF**: Must provide focused specifications to developers before any implementation begins
 
-**DEVELOPERS (python-developer, python-performance-expert, frontend-developer):**
+### DEVELOPERS (python-developer, python-performance-expert, frontend-developer):
 
 - **SCOPE**: Implement code based on architect specifications, optimize performance
 - **DELIVERABLES**: Working code, tests, performance improvements
 - **FORBIDDEN**: Making architectural decisions, changing system design without architect approval
 - **REQUIREMENTS**: Must follow architect specifications exactly, request clarification if specifications are insufficient
 
-**REVIEWERS (code-reviewer):**
+### REVIEWERS (code-reviewer):
 
 - **SCOPE**: Quality assurance, security review, standards compliance, final validation
 - **DELIVERABLES**: Code review reports, security findings, compliance verification
@@ -200,22 +200,22 @@ orchestration. For detailed architecture, see
 
 ### Subagent Prompt Requirements
 
-**DOCUMENT INGESTION ORDER (MANDATORY):**
+### DOCUMENT INGESTION ORDER (MANDATORY):
 
 Subagents must ingest documents in this specific sequence:
 
 1. **AGENTS.md FIRST** - Behavioral rules, compliance requirements, role boundaries
 2. **CONTRIBUTING.md SECOND** - Technical workflows, command reference, implementation standards
 
-**ALL SUBAGENT PROMPTS MUST INCLUDE:**
+### ALL SUBAGENT PROMPTS MUST INCLUDE:
 
 ```text
 MANDATORY: Read AGENTS.md first for compliance requirements, then CONTRIBUTING.md for technical standards.
 All requirements in the "MANDATORY Compliance Requirements for All Subagents" section are non-negotiable.
 RESPECT ROLE BOUNDARIES: Stay within your designated role scope. Do not cross into other agents' responsibilities.
-```
+```bash
 
-**Subagents MUST:**
+### Subagents MUST:
 
 - Reference and follow ALL mandatory compliance requirements above
 - Ingest both AGENTS.md (rules) and CONTRIBUTING.md (implementation) in sequence
@@ -225,7 +225,7 @@ RESPECT ROLE BOUNDARIES: Stay within your designated role scope. Do not cross in
 
 ## Quality Thresholds
 
-**Before starting any task, ensure:**
+### Before starting any task, ensure:
 
 - **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
 - **Clarity**: 7/10 - Clear implementation path and expected outcomes  
@@ -238,20 +238,20 @@ Gather more context or escalate to AGENT_REQUESTS.md
 
 ## Agent Quick Reference
 
-**Pre-Task:**
+### Pre-Task:
 
 - Read AGENTS.md → CONTRIBUTING.md for technical details
 - Confirm role: Architect|Developer|Reviewer
 - Verify quality thresholds met (Context: 8/10, Clarity: 7/10, Alignment: 8/10,
   Success: 7/10)
 
-**During Task:**
+### During Task:
 
 - Use make commands (document deviations)
 - Follow BDD approach for tests
 - Update documentation when learning patterns
 
-**Post-Task:**
+### Post-Task:
 
 - Run `make validate` - must pass all checks (code tasks only)
 - Apply core-principles post-task review: Did we forget anything? Beneficial enhancements? Something to delete?

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -6,6 +6,8 @@ created: 2025-08-19
 updated: 2026-03-07
 ---
 
+# Agent Learnings
+
 ## Template
 
 - **Context**: When/where this applies
@@ -57,7 +59,7 @@ updated: 2026-03-07
   TaskCreate(subject="Quality review", ...)    # Task 2
   TaskCreate(subject="Coverage review", ...)   # Task 3
   TaskCreate(subject="Aggregate", blockedBy=["1","2","3"])  # Task 4
-  ```
+  ```bash
 
 - **Key Finding**: Parallel reduces latency but token cost scales linearly (N teammates = N instances)
 - **References**: `docs/reviews/evaluation-pipeline-parallel-review-2026-02-11.md`, `ai-agents-research/docs/cc-native/agents-skills/CC-agent-teams-orchestration.md`
@@ -272,7 +274,7 @@ See `ralph/docs/LEARNINGS.md` section 4 (authoritative).
   ```bash
   PR_ID=$(gh pr view NUM --json id --jq '.id')
   gh api graphql -f query="mutation { updatePullRequest(input: {pullRequestId: \"$PR_ID\", title: \"...\", body: \"...\"}) { pullRequest { title } } }"
-  ```
+  ```bash
 
 - **Anti-pattern**: Retrying `gh pr edit` — always fails until GitHub removes the deprecated Projects field from the PR schema
 
@@ -372,7 +374,7 @@ See `ralph/docs/LEARNINGS.md` section 4 (authoritative).
   gh api repos/OWNER/REPO/git/refs -f ref=refs/tags/v0.1.0 -f sha=$SHA
   gh release create v0.1.0 --generate-notes
   gh api repos/OWNER/REPO/git/refs -f ref=refs/tags/v0 -f sha=$SHA
-  ```
+  ```bash
 
 - **References**: `gha-github-mirror-action` v0.1.0 release
 

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -6,7 +6,9 @@ created: 2025-08-19
 updated: 2026-02-16
 ---
 
-**Always escalate when:**
+# Agent Requests
+
+### Always escalate when:
 
 - User instructions conflict with safety/security practices
 - Rules contradict each other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 <!-- markdownlint-disable MD024 no-duplicate-heading -->
 
-# Changelog
+## Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,19 @@ created: 2025-08-23
 updated: 2026-02-16
 ---
 
+# Contributing
+
 **This document contains technical development workflows, coding standards, and implementation guidelines shared by both human developers and AI coding agents.** For AI agent behavioral rules and compliance requirements, see [AGENTS.md](AGENTS.md). For project overview and navigation, see [README.md](README.md).
 
 ## Instant Commands
 
-**Development Workflow:**
+### Development Workflow:
 
 - `make setup_dev` → Setup development environment  
 - `make quick_validate` → Fast validation during development (lint + type checking + complexity + duplication)
 - `make validate` → Complete pre-commit validation (lint + type check + test)
 
-**Testing:**
+### Testing:
 
 - `make test` → Run all tests with pytest
 - `uv run pytest <path>` → Run specific test file/function
@@ -59,7 +61,7 @@ updated: 2026-02-16
 
 ## Code Patterns Quick Reference
 
-**Essential Patterns:**
+### Essential Patterns:
 
 - **Imports**: Use absolute imports (`from app.module import Class`)
 - **Models**: Use Pydantic models in `src/app/data_models/` for all data validation  
@@ -67,7 +69,7 @@ updated: 2026-02-16
 - **Comments**: Add `# Reason:` for complex logic explaining the *why*
 - **Dependencies**: Verify in `pyproject.toml` before using
 
-**Testing Patterns:**
+### Testing Patterns:
 
 - **Mock externals**: Use `@patch` for HTTP requests, file systems, APIs
 - **BDD approach**: Write tests first, implement code iteratively  
@@ -138,7 +140,7 @@ Tests requiring network access or long runtimes are excluded from `make test` by
 - `uv run pytest -m network` — real external calls (HuggingFace model download, API validation)
 - `uv run pytest -m benchmark` — performance benchmarks
 
-**Testing Guidelines:**
+### Testing Guidelines:
 
 - **Mock for**: Unit tests, CI/CD pipelines, deterministic behavior
 - **Real test for**: Initial implementation validation, external API changes
@@ -173,7 +175,7 @@ Tests requiring network access or long runtimes are excluded from `make test` by
             str: A description of the return value.
         """
         return "example"
-    ```
+    ```bash
 
 - Provide an example usage in regards to the whole project. How would your code be integrated, what entrypoints to use
 - Update `AGENTS.md` file when introducing new patterns or concepts.
@@ -182,7 +184,7 @@ Tests requiring network access or long runtimes are excluded from `make test` by
 
 ### Code Pattern Examples
 
-**Follow these guidelines:**
+### Follow these guidelines:
 
 - ✅ Pydantic model usage vs ❌ direct dictionaries
 - ✅ Absolute imports vs ❌ relative imports  
@@ -191,13 +193,13 @@ Tests requiring network access or long runtimes are excluded from `make test` by
 - ✅ Concise, focused implementations vs ❌ verbose, feature-heavy code
 - ✅ Minimal dependencies vs ❌ heavy library usage
 
-**Always analyze existing codebase patterns before implementing anything new.**
+### Always analyze existing codebase patterns before implementing anything new.
 
 ### CHANGELOG.md Requirements
 
-**All contributors must update CHANGELOG.md for non-trivial changes.**
+### All contributors must update CHANGELOG.md for non-trivial changes.
 
-**What requires a CHANGELOG entry:**
+### What requires a CHANGELOG entry:
 
 - ✅ New features or functionality
 - ✅ Breaking changes or API modifications  
@@ -206,7 +208,7 @@ Tests requiring network access or long runtimes are excluded from `make test` by
 - ✅ Dependency updates that affect functionality
 - ✅ Configuration changes
 
-**What doesn't require a CHANGELOG entry:**
+### What doesn't require a CHANGELOG entry:
 
 - ❌ Typo fixes in comments
 - ❌ Code formatting changes
@@ -314,9 +316,9 @@ This hierarchy prevents the confusion between "what could be built" (landscape r
 
 ### Agent Integration Guidelines
 
-**For comprehensive AI agent instructions, see [AGENTS.md](AGENTS.md).**
+### For comprehensive AI agent instructions, see [AGENTS.md](AGENTS.md).
 
-**Key integration points:**
+### Key integration points:
 
 - Agent behavioral rules and compliance → [AGENTS.md](AGENTS.md)
 - Technical implementation standards → This document
@@ -349,8 +351,8 @@ mcp__context7__get-library-docs --context7CompatibleLibraryID "/pydantic/pydanti
 
 ### Requests to Humans
 
-**For agent escalation and human collaboration, see [AGENT_REQUESTS.md](AGENT_REQUESTS.md).**
+### For agent escalation and human collaboration, see [AGENT_REQUESTS.md](AGENT_REQUESTS.md).
 
 ### Agent Learning
 
-**For accumulated agent knowledge and patterns, see [AGENT_LEARNINGS.md](AGENT_LEARNINGS.md).**
+### For accumulated agent knowledge and patterns, see [AGENT_LEARNINGS.md](AGENT_LEARNINGS.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+# README
+
 <!-- markdownlint-disable MD033 -->
 
-# Agents-eval
+## Agents-eval
 
 > Evaluate multi-agent AI systems objectively — Three-tiered framework for researchers and developers building autonomous agent teams
 
@@ -29,9 +31,9 @@ A Multi-Agent System (MAS) evaluation framework using PydanticAI that generates 
 ```bash
 make setup_dev && make app_quickstart    # downloads sample data, evaluates smallest paper
 make app_cli ARGS="--help"               # all CLI options
-```
+```bash
 
-**Common commands:**
+### Common commands:
 
 ```bash
 make app_cli ARGS="--paper-id=1105.1072"                                          # evaluate a specific paper
@@ -51,7 +53,7 @@ This repo includes [RTK](https://github.com/rtk-ai/rtk) config for 60-90% LLM to
 ```bash
 make setup_rtk    # install RTK binary + activate CC PreToolUse hook (run outside CC session)
 rtk gain --graph  # view token savings
-```
+```bash
 
 Opt-out of telemetry: `export RTK_TELEMETRY_DISABLED=1`
 

--- a/docs/arch_vis/README.md
+++ b/docs/arch_vis/README.md
@@ -8,6 +8,8 @@ version: 2.0.0
 validated_links: 2026-03-12
 ---
 
+# README
+
 This directory contains PlantUML source files for the project's architecture diagrams. PNGs are rendered into `assets/images/` (light and dark themes). Source files live here; generated PNGs do not.
 
 ## Diagrams
@@ -34,7 +36,7 @@ This directory contains PlantUML source files for the project's architecture dia
 
 ```shell
 make setup_plantuml
-```
+```bash
 
 ### Generate PNGs
 
@@ -51,7 +53,7 @@ for f in docs/arch_vis/*.plantuml; do
   make plantuml_render INPUT_FILE="$f" STYLE="light" OUTPUT_PATH="assets/images"
   make plantuml_render INPUT_FILE="$f" STYLE="dark" OUTPUT_PATH="assets/images"
 done
-```
+```bash
 
 ### Interactive Mode
 
@@ -69,7 +71,7 @@ Replace:
 
 ```plantuml
 !include styles/github-$STYLE.puml
-```
+```text
 
 With (light):
 
@@ -81,6 +83,6 @@ Or (dark):
 
 ```plantuml
 !include https://raw.githubusercontent.com/qte77/Agents-eval/main/docs/arch_vis/styles/github-dark.puml
-```
+```text
 
 Then paste the modified source into the web editor.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,8 @@ category: architecture
 version: 3.9.0
 validated_links: 2026-03-12
 ---
+# Architecture
+
 <!-- markdownlint-disable MD024 no-duplicate-heading -->
 
 This document provides detailed architecture information for the Agents-eval Multi-Agent System (MAS) evaluation framework.
@@ -89,7 +91,7 @@ Individual tier results are in-memory during pipeline execution. Per-run `evalua
 2. **Assembly**: Results are packed into an `EvaluationResults` dataclass (with fallback fill-in if tiers are missing).
 3. **Composite scoring**: `CompositeScorer` combines tier results into a single `CompositeResult` — this is the only object returned to callers.
 
-**`CompositeResult` consumers:**
+### `CompositeResult` consumers:
 
 | Consumer | Location | Purpose |
 | --- | --- | --- |
@@ -113,13 +115,13 @@ Individual tier results are in-memory during pipeline execution. Per-run `evalua
 | Tier 2 (LLM-Judge) | Semantic | Quality assessment via LLM |
 | Tier 3 (Graph) | Behavioral | Coordination patterns from execution traces |
 
-**Validation Logic:**
+### Validation Logic:
 
 - **All 3 tiers agree** → High confidence in MAS quality
 - **Tier 3 good, Tier 1/2 fail** → Good coordination, poor output quality
 - **Tier 1/2 good, Tier 3 fail** → Good output, inefficient coordination
 
-**Design Goals:**
+### Design Goals:
 
 - **Graph (Tier 3)**: Rich analysis from execution traces — project's differentiator
 - **Traditional (Tier 1)**: Lightweight metrics only
@@ -207,7 +209,7 @@ The benchmarking pipeline enables systematic comparison of MAS compositions with
 
 ```text
 SweepConfig → SweepRunner → (compositions × papers × repetitions) → SweepAnalyzer → output files
-```
+```bash
 
 - **`SweepConfig`** (`src/app/benchmark/sweep_config.py`): Declares sweep parameters — agent compositions (2³ = 8 default), paper IDs, repetitions per combination, provider settings
 - **`SweepRunner`** (`src/app/benchmark/sweep_runner.py`): Executes the sweep matrix, calls `evaluation_pipeline.evaluate_comprehensive()` for each cell, aggregates raw results
@@ -298,7 +300,7 @@ The CC path feeds Claude Code agent artifacts into the same evaluation pipeline 
 ```text
 Solo:  claude -p "prompt" --output-format json        → CCResult → extract_cc_review_text → evaluate_comprehensive
 Teams: claude -p "prompt" --output-format stream-json  → Popen JSONL stream → CCResult → cc_result_to_graph_trace → evaluate_comprehensive
-```
+```text
 
 `check_cc_available()` (`src/app/engines/cc_engine.py`) wraps `shutil.which("claude")` for fail-fast validation. Teams mode sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and parses `init`, `result`, `TeamCreate`, and `Task` events from the live JSONL stream via `Popen`, since CC teams artifacts (`~/.claude/teams/`, `~/.claude/tasks/`) are ephemeral in print mode (see AGENT_LEARNINGS.md).
 
@@ -373,7 +375,7 @@ _Agents-eval/
         summary.md        ← Markdown table with mean/stddev per metric per composition
     reports/
       {timestamp}.md      ← standalone reports (CLI --generate-report without run)
-```
+```text
 
 ### Output Decision Tree
 
@@ -504,7 +506,7 @@ For CC engines, `cc_result_to_graph_trace()` (`src/app/engines/cc_engine.py:255`
 ```text
 MAS path:   TraceCollector.complete_trace() → _store_trace() → traces.db + trace.json
 CC path:    CCResult.team_artifacts → cc_result_to_graph_trace() → GraphTraceData (in-memory)
-```
+```yaml
 
 #### Stage 2: NetworkX Graph Construction
 
@@ -531,7 +533,7 @@ The GUI stores the graph in Streamlit session state (`run_app.py:284`):
 
 ```python
 st.session_state.execution_graph = result.get("graph")
-```
+```text
 
 When the user navigates to the Agent Graph page, `render_agent_graph()` (`src/gui/pages/agent_graph.py:44`) converts the `nx.DiGraph` into an interactive HTML visualization using Pyvis:
 
@@ -559,7 +561,7 @@ Post-evaluation report generation synthesizes tier scores into actionable Markdo
 
 ```text
 CompositeResult → SuggestionEngine → [Suggestion, ...] → ReportGenerator → Markdown report
-```
+```python
 
 - **`SuggestionEngine`** (`src/app/reports/suggestion_engine.py`): Iterates `metric_scores`, compares each against tier thresholds from `JudgeSettings` (accept=0.8, weak_accept=0.6, weak_reject=0.4). Assigns severity (critical/warning/info). Optional LLM enrichment via judge provider with rule-based fallback.
 - **`ReportGenerator`** (`src/app/reports/report_generator.py`): Produces structured Markdown: executive summary, per-tier breakdown, weakness identification, actionable suggestions from the engine.
@@ -798,7 +800,7 @@ class JudgeSettings(BaseSettings):
     tier2_provider: str = "auto"
     tier2_model: str = "gpt-4o-mini"
     # ... 30+ settings covering per-tier config, thresholds, tracing, observability
-```
+```text
 
 #### Typed Context Passing
 

--- a/docs/best-practices/testing-strategy.md
+++ b/docs/best-practices/testing-strategy.md
@@ -7,6 +7,8 @@ see-also: tdd-best-practices.md, bdd-best-practices.md
 validated_links: 2026-03-12
 ---
 
+# Testing Strategy
+
 **Purpose**: What to test, when to use each tool, test organization,
 running commands.
 
@@ -136,7 +138,7 @@ def test_result_with_timestamp():
         "score": 0.85,
         "timestamp": IsDatetime(),  # Not managed by snapshot
     })
-```
+```bash
 
 **Commands**:
 
@@ -241,7 +243,7 @@ def test_order_repository_saves_order(tmp_path):
     repo = OrderRepository(db)
     order = repo.save(Order(total=100))
     assert repo.get(order.id).total == 100
-```
+```text
 
 ### Priority Test Areas
 
@@ -278,7 +280,7 @@ tests/
 │   ├── features/*.feature
 │   └── step_defs/
 └── conftest.py           # Shared fixtures
-```
+```bash
 
 ## Running Tests
 

--- a/docs/best-practices/troubleshooting.md
+++ b/docs/best-practices/troubleshooting.md
@@ -51,7 +51,7 @@ echo $GITHUB_API_KEY
 # For other providers (Cerebras, Groq, etc.)
 echo $CEREBRAS_API_KEY
 echo $GROQ_API_KEY
-```
+```python
 
 #### 2. Configure Fallback Provider
 
@@ -93,7 +93,7 @@ if selected is None:
 else:
     provider, model = selected
     print(f"Using provider: {provider}/{model}")
-```
+```text
 
 ### Expected Behavior
 
@@ -134,7 +134,7 @@ Enable debug logging to see provider selection details:
 ```python
 import logging
 logging.getLogger("app.judge.llm_evaluation_managers").setLevel(logging.DEBUG)
-```
+```text
 
 You'll see logs like:
 

--- a/docs/howtos/maintaining-agents-md.md
+++ b/docs/howtos/maintaining-agents-md.md
@@ -8,9 +8,11 @@ version: 1.1.0
 validated_links: 2026-03-12
 ---
 
+# Maintaining Agents MD
+
 This document outlines a strategy to ensure the agent governance files remain synchronized with the state of the codebase, preventing them from becoming outdated. Accurate governance files are critical for safe, effective AI agent operation.
 
-**Agent governance files:**
+### Agent governance files:
 
 | File | Purpose | Authority |
 |------|---------|-----------|
@@ -37,7 +39,7 @@ Integrate documentation updates into the core development workflow, making them 
 - [ ] `AGENT_REQUESTS.md` — resolved requests removed; new blockers added if any
 - [ ] `CONTRIBUTING.md` updated if commands, paths, or coding standards changed
 - [ ] Docstrings added/updated for all new/modified functions and classes
-```
+```bash
 
 The template also enforces `make validate` passes and security checks. See `.github/pull_request_template.md` for the full template.
 
@@ -76,7 +78,7 @@ The Ralph loop (`ralph/scripts/ralph.sh`) is the primary autonomous task executi
 ```bash
 make ralph_init        # Initialize state for a new sprint
 make ralph ITERATIONS=N  # Run autonomous loop
-```
+```yaml
 
 Post-sprint: ensure `AGENT_LEARNINGS.md` reflects any new patterns discovered during Ralph execution. The Ralph-specific learnings log in `ralph/docs/LEARNINGS.md` is a source for promoting patterns to the project-level `AGENT_LEARNINGS.md`.
 

--- a/docs/howtos/peerread-agent-usage.md
+++ b/docs/howtos/peerread-agent-usage.md
@@ -8,6 +8,8 @@ version: 3.1.0
 validated_links: 2026-03-12
 ---
 
+# Peerread Agent Usage
+
 For quick start, module architecture, and review storage details, see [README.md](../../README.md) and [architecture.md](../architecture.md).
 
 ## Available Agent Tools
@@ -24,7 +26,7 @@ The agent has access to the following tools, defined in `src/app/tools/peerread_
 
 - **`generate_paper_review_content_from_template(paper_id: str, review_focus: str = "comprehensive", tone: str = "professional") -> str`**: Creates a review template for a specific paper. **WARNING**: This creates a template structure, not an actual review. Designed for demonstration purposes.
 
-**Parameters:**
+### Parameters:
 
 - `review_focus`: Type of review — `"comprehensive"`, `"technical"`, `"high-level"`
 - `tone`: Review tone — `"professional"`, `"constructive"`, `"critical"`
@@ -34,7 +36,7 @@ The agent has access to the following tools, defined in `src/app/tools/peerread_
 - **`save_structured_review(paper_id: str, structured_review: GeneratedReview) -> str`**: Saves a validated `GeneratedReview` object to persistent storage. **Recommended** for structured reviews.
 - **`save_paper_review(paper_id: str, review_text: str, recommendation: str = "", confidence: float = 0.0) -> str`**: Saves raw review text with optional recommendation and confidence scores.
 
-**Storage Format:**
+### Storage Format:
 
 - Files saved as: `{paper_id}_{timestamp}.json`
 - Structured reviews also create: `{paper_id}_{timestamp}_structured.json`
@@ -52,7 +54,7 @@ make app_cli ARGS="--download-peerread-full-only"
 
 # Limit sample download size
 make app_cli ARGS="--download-peerread-samples-only --peerread-max-papers-per-sample-download 50"
-```
+```bash
 
 ### Agent Configuration
 
@@ -78,7 +80,7 @@ make app_cli ARGS="--paper-id=1105.1072 --generate-report"
 
 # Override Tier 2 judge provider/model
 make app_cli ARGS="--paper-id=1105.1072 --judge-provider=openai --judge-model=gpt-4o"
-```
+```bash
 
 ### Review Tools Control
 
@@ -101,7 +103,7 @@ make app_cli ARGS="--paper-id=1105.1072 --engine=cc"
 
 # Claude Code with Agent Teams mode
 make app_cli ARGS="--paper-id=1105.1072 --engine=cc --cc-teams"
-```
+```bash
 
 ### Sweep & Profiling
 
@@ -122,28 +124,28 @@ All providers configured in `src/app/config/config_chat.json` are available. Com
 
 ```bash
 make app_cli ARGS="--paper-id=1105.1072 --chat-provider=openai"
-```
+```bash
 
 ## Troubleshooting
 
-**Paper not found error:**
+### Paper not found error:
 
 - Ensure PeerRead dataset is downloaded: `make app_cli ARGS="--download-peerread-samples-only"`
 - Paper IDs are arxiv IDs (e.g., `1105.1072`), not sequential numbers
 - Use `query_peerread_papers` via the agent to list available papers
 
-**Agent tools not working:**
+### Agent tools not working:
 
 - Verify chat provider configuration in `config_chat.json`
 - Check API keys are set in `.env` for the chosen provider
 - Review logs for specific error messages
 
-**Review saving failures:**
+### Review saving failures:
 
 - Ensure output directory is writable (created automatically on first run)
 - Verify `GeneratedReview` object structure for structured reviews
 
-**Claude Code engine failures (`--engine=cc`):**
+### Claude Code engine failures (`--engine=cc`):
 
 - Check `claude` CLI is installed: `which claude`
 - Ensure `ANTHROPIC_API_KEY` is set in `.env`

--- a/docs/ralph-archive/LEARNINGS.md
+++ b/docs/ralph-archive/LEARNINGS.md
@@ -6,6 +6,8 @@ created: 2026-02-10
 updated: 2026-03-08
 ---
 
+# Learnings
+
 ## 1. Story Completion Checklist
 
 - [ ] AC tests behavior, not shape ("returns score>20" not "returns dict")
@@ -31,7 +33,7 @@ BAD:  - [ ] Module with:        ← parser sees 1 item
 GOOD: - [ ] Module created       ← parser sees 3 items
       - [ ] helper_a()
       - [ ] helper_b()
-```
+```bash
 
 ## 3. Platform Integration
 
@@ -71,7 +73,7 @@ PRD `files` lists are authored manually and often miss pre-existing tests that a
 
 **Sprint 8 incident**: Three stories (STORY-001, STORY-011, STORY-012) each passed `make validate` but left stale tests in `tests/security/` and `tests/test_gui/` because those files weren't in the PRD `files` list. The OOM-hanging test masked the failures by killing the process before reaching them.
 
-**Mitigations:**
+### Mitigations:
 
 - [x] **Impact grep before implementation**: When a story renames a symbol or changes observable behavior, grep the full test tree for the old value. Add any consuming test file to the story scope, even if not in the PRD `files` list. Implemented as prompt instruction in `prompt.md` (impact scan section).
 - [x] **Distinguish killed vs failed validation**: Exit codes 137/143 (SIGTERM/OOM) mean `make validate` was killed -- result is inconclusive, not PASS. Ralph should retry or flag, never record PASS. Implemented as inline check in `baseline.sh:run_quality_checks_baseline()`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,8 @@ version: 4.6.0
 validated_links: 2026-03-12
 ---
 
+# Roadmap
+
 Sprint timeline for Agents-eval. See [architecture.md](architecture.md) for technical decisions (ADRs).
 
 | Sprint | Status | Goal | Reference |

--- a/docs/security-advisories.md
+++ b/docs/security-advisories.md
@@ -14,7 +14,7 @@ Known CVE advisories affecting dependencies and their applicability to this proj
 
 ## CVE-2026-25580: PydanticAI SSRF Vulnerability (CRITICAL)
 
-**Status**: **MITIGATED**
+### Status**: **MITIGATED
 
 **Severity**: CRITICAL
 **Published**: 2026-02-09
@@ -49,7 +49,7 @@ Note: LLM provider APIs (OpenAI, Anthropic, Cerebras, etc.) are called through P
 
 ## CVE-2026-25640: PydanticAI Stored XSS via Path Traversal (HIGH)
 
-**Status**: **NOT APPLICABLE**
+### Status**: **NOT APPLICABLE
 
 **Severity**: HIGH
 **Published**: 2026-02-06
@@ -77,7 +77,7 @@ Path Traversal vulnerability in PydanticAI web UI allows attackers to serve arbi
 
 ## CVE-2024-5206: scikit-learn Sensitive Data Leakage (MEDIUM)
 
-**Status**: **MITIGATED**
+### Status**: **MITIGATED
 
 **Severity**: MEDIUM (CVSS 5.3)
 **Published**: 2024-06-06

--- a/docs/write-up/en/2026-02-18/04_planning_and_solution.md
+++ b/docs/write-up/en/2026-02-18/04_planning_and_solution.md
@@ -111,7 +111,7 @@ The implementation resides in `src/app/judge/composite_scorer.py`.
 
 The composite score calculation follows the formula:
 
-```
+```text
 Agent Score = Weighted sum of six core metrics
 ```
 
@@ -137,7 +137,7 @@ if single_agent_mode and tier2_skipped:
     available_metrics = [m for m in all_metrics
                          if m not in excluded_metrics]
     weight_per_metric = 1.0 / len(available_metrics)
-```
+```python
 
 *Code excerpt from `src/app/judge/composite_scorer.py`*
 
@@ -193,7 +193,7 @@ class PluginRegistry:
     def register(self, plugin: EvaluatorPlugin) -> None: ...
     def get_plugins_by_tier(self, tier: int) -> list[EvaluatorPlugin]: ...
     def execute_all(self, context: BaseModel) -> list[BaseModel]: ...
-```
+```python
 
 *Code excerpt from `src/app/judge/`*
 

--- a/docs/write-up/en/2026-02-18/05_implementation.md
+++ b/docs/write-up/en/2026-02-18/05_implementation.md
@@ -21,7 +21,7 @@ async def main(
     skip_eval: bool = False,
     ...
 ) -> dict[str, Any] | None:
-```
+```python
 
 *Code excerpt from `src/app/app.py:196`*
 
@@ -51,7 +51,7 @@ All data boundaries are secured by Pydantic models in `src/app/data_models/`. Th
 
 ```python
 impact: str = Field(default="UNKNOWN", validation_alias="IMPACT")
-```
+```python
 
 *Code excerpt from `src/app/data_models/peerread_models.py`*
 
@@ -94,7 +94,7 @@ async def delegate_research(
     )
     result = await research_agent.run(query, usage=ctx.usage)
     ...
-```
+```yaml
 
 *Code excerpt from `src/app/agents/agent_system.py:121`*
 
@@ -157,7 +157,7 @@ class EvaluatorPlugin(ABC):
 
     @abstractmethod
     def get_context_for_next_tier(self, result: BaseModel) -> BaseModel: ...
-```
+```python
 
 *Code excerpt from `src/app/judge/plugins/base.py`*
 
@@ -198,7 +198,7 @@ Example invocation:
 ```bash
 make app_cli ARGS="--paper-number=1105.1072 --chat-provider=github \
     --include-researcher --include-analyst --include-synthesiser"
-```
+```text
 
 ### Streamlit GUI
 

--- a/docs/write-up/en/2026-02-18/06_control_of_success.md
+++ b/docs/write-up/en/2026-02-18/06_control_of_success.md
@@ -79,7 +79,7 @@ Dependencies are managed via `uv` with pinned versions. CVE-2024-5206 (scikit-le
 
 Based on the actual trace data collected from `logs/traces/` (30 JSONL traces, 14 Manager-only runs, 12 multi-agent runs) [@mas-findings], the current implementation status can be assessed as follows:
 
-**Implemented and functional:**
+### Implemented and functional:
 
 - Three-tier evaluation pipeline with plugin architecture and composite scorer
 - PydanticAI MAS with four agent roles and flexible composition configuration
@@ -89,7 +89,7 @@ Based on the actual trace data collected from `logs/traces/` (30 JSONL traces, 1
 - CCTraceAdapter for CC Solo mode parsing
 - Streamlit GUI with background execution, debug log, evaluation, and graph views
 
-**Not completed or blocked:**
+### Not completed or blocked:
 
 - Complete MAS vs. CC comparison with composite scores (CC Teams artifacts ephemeral; API key for Tier 2 LLM-as-Judge not set in test environment)
 - Composition sweep with statistically significant results (empty `results/sweeps/` directories; blocked by the now-fixed `AgentRunResult.data` bug)

--- a/docs/write-up/en/2026-02-18/10_appendices.md
+++ b/docs/write-up/en/2026-02-18/10_appendices.md
@@ -76,11 +76,11 @@ The complete hierarchy is described in [AGENTS.md](../../../../AGENTS.md). The f
 \caption{Documentation hierarchy}
 \end{figure}
 
-**Authority Chain (Reference Flow):**
+### Authority Chain (Reference Flow):
 
 ```text
 PRD.md (Requirements) $\rightarrow$ architecture.md (Technical Design)
   $\rightarrow$ Sprint Documents (Implementation) $\rightarrow$ Usage Guides (Operations)
         ↑
 Landscape Documents (inform strategic decisions, do not create requirements)
-```
+```text

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -8,17 +8,17 @@ Self-contained demonstrations of Agents-eval Sprint 5-11 features using current 
 
 Demonstrates the `EvaluationPipeline` with realistic paper/review data.
 
-**What it shows:**
+### What it shows:
 
 - Constructing `GraphTraceData` for a 3-agent MAS execution
 - Running Tier 1 (Traditional Metrics) + Tier 3 (Graph Analysis)
 - Interpreting `CompositeResult` (score, recommendation, tier breakdown)
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/basic_evaluation.py
-```
+```bash
 
 **Prerequisites:** None for Tier 1 + Tier 3. Add `OPENAI_API_KEY` to `.env` and set
 `tiers_enabled=[1, 2, 3]` to also run Tier 2 (LLM-as-Judge).
@@ -29,7 +29,7 @@ uv run python src/examples/basic_evaluation.py
 
 Demonstrates how to configure the evaluation pipeline via `JudgeSettings`.
 
-**What it shows:**
+### What it shows:
 
 - Environment variable overrides (`JUDGE_` prefix, e.g. `JUDGE_TIER2_PROVIDER=anthropic`)
 - Timeout adjustment for slow/fast environments
@@ -37,7 +37,7 @@ Demonstrates how to configure the evaluation pipeline via `JudgeSettings`.
 - Provider switching (OpenAI → Anthropic → GitHub)
 - Composite score threshold customization
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/judge_settings_customization.py
@@ -51,20 +51,20 @@ uv run python src/examples/judge_settings_customization.py
 
 Demonstrates comparing evaluation scores between MAS and Claude Code engines.
 
-**What it shows:**
+### What it shows:
 
 - Multi-LLM MAS evaluation (synthetic 3-agent trace)
 - Single-LLM MAS baseline evaluation
 - Loading CC artifacts via `CCTraceAdapter` (optional, requires prior collection)
 - Side-by-side score comparison
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/engine_comparison.py
-```
+```bash
 
-**Prerequisites:**
+### Prerequisites:
 
 For MAS-only comparison: None (uses synthetic traces).
 
@@ -88,17 +88,17 @@ specify. Set the `cc_artifacts_dir` variable in the script if your path differs.
 Demonstrates the minimal MAS execution mode where only the manager agent runs
 (no sub-agents). All `include_*` flags are `False`.
 
-**What it shows:**
+### What it shows:
 
 - Running `app.main()` in manager-only (single-agent) mode
 - How to set `include_researcher=False`, `include_analyst=False`, `include_synthesiser=False`
 - Interpreting `CompositeResult` from the single-agent run
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/mas_single_agent.py
-```
+```bash
 
 **Prerequisites:** API key for the default LLM provider in `.env`. PeerRead sample
 dataset downloaded (`make setup_dataset`).
@@ -110,13 +110,13 @@ dataset downloaded (`make setup_dataset`).
 Demonstrates the full MAS execution mode with manager delegating to all three
 sub-agents: researcher, analyst, and synthesiser.
 
-**What it shows:**
+### What it shows:
 
 - Running `app.main()` with all `include_*` flags set to `True`
 - Full 4-agent delegation workflow (manager → researcher → analyst → synthesiser)
 - Composite score comparison vs. single-agent mode
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/mas_multi_agent.py
@@ -132,18 +132,18 @@ dataset downloaded (`make setup_dataset`).
 Demonstrates running Claude Code in solo headless mode via `run_cc_solo()` with
 a `check_cc_available()` guard and `build_cc_query()` for query construction.
 
-**What it shows:**
+### What it shows:
 
 - Checking CC availability with `check_cc_available()`
 - Building a query with `build_cc_query()`
 - Invoking `run_cc_solo()` and inspecting the `CCResult`
 - Graceful handling when `claude` CLI is not on PATH
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/cc_solo.py
-```
+```bash
 
 **Prerequisites:** Claude Code CLI installed (`claude --version`) and authenticated
 (`claude` interactive session). No LLM API keys required.
@@ -155,14 +155,14 @@ uv run python src/examples/cc_solo.py
 Demonstrates running Claude Code in agent-teams orchestration mode via
 `run_cc_teams()`, which sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
 
-**What it shows:**
+### What it shows:
 
 - Building a teams-mode query with `build_cc_query(cc_teams=True)`
 - Invoking `run_cc_teams()` and inspecting `task_started`/`task_completed` events in `CCResult`
 - How team artifacts are captured from the live JSONL stream
 - Graceful handling when `claude` CLI is not on PATH
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/cc_teams.py
@@ -178,18 +178,18 @@ Teams mode requires Claude Max or API subscription with agent teams enabled.
 Demonstrates running a multi-composition sweep using `SweepRunner` and
 `SweepConfig`. Evaluates 3 compositions on 1 paper with 1 repetition.
 
-**What it shows:**
+### What it shows:
 
 - Configuring `SweepConfig` with multiple `AgentComposition` instances
 - Running `SweepRunner.run()` across all compositions
 - Using a temporary directory for `output_dir` (auto-cleaned up)
 - Comparing composite scores across compositions
 
-**Usage:**
+### Usage:
 
 ```bash
 uv run python src/examples/sweep_benchmark.py
-```
+```bash
 
 **Prerequisites:** API key for the default LLM provider in `.env`. PeerRead sample
 dataset downloaded (`make setup_dataset`). Runs 3 LLM calls (one per composition).


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>